### PR TITLE
[OZN 1139] [Useneutral] Primeira ordem de serviço

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ozmap/ozn-sdk",
-  "version": "0.0.1-1058-6",
+  "version": "0.0.1-1139-1",
   "description": "OZN SDK is a powerful tool for developers to build their own applications on top of OZN using TMForum pattern.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ozmap/ozn-sdk",
-  "version": "0.0.1-1058-5",
+  "version": "0.0.1-1058-6",
   "description": "OZN SDK is a powerful tool for developers to build their own applications on top of OZN using TMForum pattern.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/types/service-ordering.ts
+++ b/src/types/service-ordering.ts
@@ -21,6 +21,8 @@ const resourceSchema = z
 
 export const ServiceOrderActionEnum = z.enum(['add', 'modify', 'delete', 'modifyPort']);
 
+export const ServiceOrderStateEnum = z.enum(['Completed', 'Held', 'InProgress', 'Cancelled', 'Failed'])
+
 export const PortReplaceDetailEnum = z.enum([
     'crossing',
     'closerCTO',
@@ -91,7 +93,7 @@ export const ServiceOrderOutputSchema = z.object({
     description: z.string().nullable(),
     category: z.string(),
     note: z.string(),
-    state: z.string(),
+    state: ServiceOrderStateEnum,
     orderDate: z.string(),
     requesterCallback: z.string(),
     relatedParty: z.array(
@@ -110,7 +112,7 @@ export const ServiceOrderOutputSchema = z.object({
             id: z.string(),
             action: ServiceOrderActionEnum,
             requestedCompletionDate: z.string().nullable(),
-            state: z.string(),
+            state: ServiceOrderStateEnum,
             statusMessage: z.string().nullable(),
             serviceSpecification: z.object({
                 id: z.string(),


### PR DESCRIPTION
Adicionados enum de state que não estavam no ServiceOrderManagement:

Segue o embasamento da adição:
![image](https://github.com/user-attachments/assets/584c31e3-a541-40fc-89be-40a2a2486ecb)
![image](https://github.com/user-attachments/assets/65c3d3f1-d02f-45fa-8da1-589b24520185)

